### PR TITLE
Remove cfg from mock

### DIFF
--- a/codegen/src/mock.rs
+++ b/codegen/src/mock.rs
@@ -145,7 +145,6 @@ pub fn generate(_: TokenStream, input: TokenStream) -> Result<TokenStream, Error
         });
 
     Ok(quote! {
-        #[cfg(feature = "ink-std")]
         pub fn register_chain_extensions #types (ctx: #item) {
             #[allow(unused_variables)]
             let wrapped_context = ::std::rc::Rc::new(::std::cell::RefCell::new(ctx));


### PR DESCRIPTION
The `ink-std` feature is implied from the `[dev-dependencies]` section of a contract, and `cfg`-ing it makes `register_chain_extensions` function impossible to use from contract's tests.